### PR TITLE
JBIDE-22318 - cleanup, fix build error, revert api change

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/.classpath
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="jbosscore"/>
 	<classpathentry exported="true" kind="lib" path="dom4j-1.6.1.jar"/>

--- a/as/plugins/org.jboss.ide.eclipse.as.core/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/META-INF/MANIFEST.MF
@@ -63,4 +63,4 @@ Bundle-ClassPath: dom4j-1.6.1.jar,
  getopt.jar,
  .
 Bundle-Vendor: %Bundle-Vendor.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/util/ClassCollectingHCRListener.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/util/ClassCollectingHCRListener.java
@@ -26,7 +26,9 @@ public final class ClassCollectingHCRListener extends ServerHotCodeReplaceListen
 		super(server, launch);
 	}
 
-	protected void postPublish(IJavaDebugTarget target, IServer server, IModule[] modules) {
+	@Override
+	protected void postPublish(IJavaDebugTarget target, IModule[] modules) {
+		IServer server = getServer();
 		waitModulesStarted(modules);
 		removeBreakpoints(target);
 		executeJMXGarbageCollection(server, modules);

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/util/ClassCollectingHCRListener.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/util/ClassCollectingHCRListener.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.util;
 
 import java.io.IOException;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/ServerHotCodeReplaceListener.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/ServerHotCodeReplaceListener.java
@@ -66,11 +66,20 @@ public class ServerHotCodeReplaceListener implements IJavaHotCodeReplaceListener
 	public static final int TERMINATE = 4;
 
 	private IServer server;
-
+	private ILaunch launch;
 	public ServerHotCodeReplaceListener(IServer server, ILaunch launch) {
 		this.server = server;
+		this.launch = launch;
 	}
 
+	protected IServer getServer() {
+		return server;
+	}
+	
+	protected ILaunch getLaunch() {
+		return launch;
+	}
+	
 	public void hotCodeReplaceSucceeded(IJavaDebugTarget arg0) {
 		// ignore
 	}
@@ -107,7 +116,7 @@ public class ServerHotCodeReplaceListener implements IJavaHotCodeReplaceListener
 		IServer.IOperationListener listener = new IServer.IOperationListener() {
 
 			public void done(IStatus result) {
-				postPublish(target, server, modules);
+				postPublish(target, modules);
 			}
 		};
 		server.publish(IServer.PUBLISH_FULL, Collections.singletonList(modules), null, listener);
@@ -119,7 +128,7 @@ public class ServerHotCodeReplaceListener implements IJavaHotCodeReplaceListener
 	 * @param server
 	 * @param modules
 	 */
-	protected void postPublish(IJavaDebugTarget target, IServer server, IModule[] modules) {
+	protected void postPublish(IJavaDebugTarget target, IModule[] modules) {
 	}
 	
 	/**


### PR DESCRIPTION
Hi Thomas:

I'm making this PR back to you so you can see what I've done differently before accepting your patch. The first is I've changed references to JavaSE-1.6 to JavaSE1.8. 

The second is I've reverted the change to ServerHotCodeReplaceListener in the method signature for postPublish.  Other classes out of our product (ie, Fuse, or others) may be using this class, so it is not appropriate to change the method signature without a good reason. 

In this case, I've simply opted to add a protected getter() for the IServer (and another for the ILaunch, just in case).  This is a better solution than changing an existing method signature. 
